### PR TITLE
feat: Add commit messages to version report

### DIFF
--- a/versioning/report.go
+++ b/versioning/report.go
@@ -15,13 +15,13 @@ import (
 type BumpType string
 
 const (
-	BumpMajor BumpType  = "major"
-	BumpMinor BumpType  = "minor"
-	BumpPatch BumpType  = "patch"
-	BumpGraduate BumpType  = "graduate"
-	BumpPrerelease BumpType  = "prerelease"
-	BumpCustom BumpType = "custom"
-	BumpNone  BumpType  = "none"
+	BumpMajor      BumpType = "major"
+	BumpMinor      BumpType = "minor"
+	BumpPatch      BumpType = "patch"
+	BumpGraduate   BumpType = "graduate"
+	BumpPrerelease BumpType = "prerelease"
+	BumpCustom     BumpType = "custom"
+	BumpNone       BumpType = "none"
 )
 
 type VersionReport struct {
@@ -32,6 +32,7 @@ type VersionReport struct {
 	NewVersion   string   `json:"new_version"`
 	MustGenerate bool     `json:"must_generate"`
 	PRReport     string   `json:"pr_report"`
+	CommitReport *string  `json:"commit_report"`
 }
 
 const ENV_VAR_PREFIX = "SPEAKEASY_VERSION_REPORT_LOCATION"
@@ -93,6 +94,17 @@ func (m *MergedVersionReport) GetMarkdownSection() string {
 		}
 	}
 	return inner
+}
+
+func (m *MergedVersionReport) GetCommitMarkdownSection() string {
+	inner := ""
+	for _, report := range m.Reports {
+		if report.CommitReport != nil && len(*report.CommitReport) > 0 {
+			inner += *report.CommitReport + "\n"
+		}
+	}
+	return inner
+
 }
 
 func getMergedVersionReport() (*MergedVersionReport, error) {

--- a/versioning/report.go
+++ b/versioning/report.go
@@ -32,7 +32,7 @@ type VersionReport struct {
 	NewVersion   string   `json:"new_version"`
 	MustGenerate bool     `json:"must_generate"`
 	PRReport     string   `json:"pr_report"`
-	CommitReport *string  `json:"commit_report"`
+	CommitReport string   `json:"commit_report"`
 }
 
 const ENV_VAR_PREFIX = "SPEAKEASY_VERSION_REPORT_LOCATION"
@@ -99,8 +99,8 @@ func (m *MergedVersionReport) GetMarkdownSection() string {
 func (m *MergedVersionReport) GetCommitMarkdownSection() string {
 	inner := ""
 	for _, report := range m.Reports {
-		if report.CommitReport != nil && len(*report.CommitReport) > 0 {
-			inner += *report.CommitReport + "\n"
+		if len(report.CommitReport) > 0 {
+			inner += report.CommitReport + "\n"
 		}
 	}
 	return inner

--- a/versioning/report_test.go
+++ b/versioning/report_test.go
@@ -60,7 +60,7 @@ func TestAddVersionReportWithCommitReport(t *testing.T) {
 		BumpType:     BumpMinor,
 		MustGenerate: true,
 		PRReport:     "Test report",
-		CommitReport: &commitReport,
+		CommitReport: commitReport,
 	}
 
 	err = AddVersionReport(ctx, report)
@@ -74,8 +74,7 @@ func TestAddVersionReportWithCommitReport(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, report, readReport)
-	assert.NotNil(t, readReport.CommitReport)
-	assert.Equal(t, commitReport, *readReport.CommitReport)
+	assert.Equal(t, commitReport, readReport.CommitReport)
 }
 
 func TestGetMergedVersionReport(t *testing.T) {
@@ -118,8 +117,8 @@ func TestGetMergedVersionReportWithCommitReports(t *testing.T) {
 	commitReport1 := "Test commit report 1"
 	commitReport2 := "Test commit report 2"
 	reports := []VersionReport{
-		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &commitReport1},
-		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: &commitReport2},
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: commitReport1},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: commitReport2},
 	}
 
 	for _, report := range reports {
@@ -148,10 +147,10 @@ func TestGetMergedVersionReportWithMixedCommitReports(t *testing.T) {
 	defer os.Unsetenv(ENV_VAR_PREFIX)
 
 	commitReport1 := "Test commit report 1"
-	// test2 has no commit report (nil)
+	// test2 has no commit report (empty string)
 	reports := []VersionReport{
-		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &commitReport1},
-		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: nil},
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: commitReport1},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: ""},
 	}
 
 	for _, report := range reports {
@@ -179,11 +178,9 @@ func TestGetMergedVersionReportWithEmptyCommitReports(t *testing.T) {
 	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
 	defer os.Unsetenv(ENV_VAR_PREFIX)
 
-	emptyCommitReport1 := ""
-	emptyCommitReport2 := ""
 	reports := []VersionReport{
-		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &emptyCommitReport1},
-		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: &emptyCommitReport2},
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: ""},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: ""},
 	}
 
 	for _, report := range reports {
@@ -233,7 +230,7 @@ func TestWithVersionReportCaptureWithCommitReport(t *testing.T) {
 			Priority:     1,
 			MustGenerate: true,
 			PRReport:     "Test report",
-			CommitReport: &commitReport,
+			CommitReport: commitReport,
 		})
 	})
 
@@ -241,8 +238,7 @@ func TestWithVersionReportCaptureWithCommitReport(t *testing.T) {
 	assert.Len(t, report.Reports, 1)
 	assert.Equal(t, "test_commit", report.Reports[0].Key)
 	assert.True(t, report.MustGenerate())
-	assert.NotNil(t, report.Reports[0].CommitReport)
-	assert.Equal(t, commitReport, *report.Reports[0].CommitReport)
+	assert.Equal(t, commitReport, report.Reports[0].CommitReport)
 	assert.Equal(t, "Test commit report\n", report.GetCommitMarkdownSection())
 }
 

--- a/versioning/report_test.go
+++ b/versioning/report_test.go
@@ -44,6 +44,40 @@ func TestAddVersionReport(t *testing.T) {
 	assert.Equal(t, report, readReport)
 }
 
+func TestAddVersionReportWithCommitReport(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_version_report_commit.json")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
+	defer os.Unsetenv(ENV_VAR_PREFIX)
+
+	ctx := context.Background()
+	commitReport := "Test commit report"
+	report := VersionReport{
+		Key:          "test_commit",
+		Priority:     1,
+		BumpType:     BumpMinor,
+		MustGenerate: true,
+		PRReport:     "Test report",
+		CommitReport: &commitReport,
+	}
+
+	err = AddVersionReport(ctx, report)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(tempFile.Name())
+	require.NoError(t, err)
+
+	var readReport VersionReport
+	err = json.Unmarshal(content, &readReport)
+	require.NoError(t, err)
+
+	assert.Equal(t, report, readReport)
+	assert.NotNil(t, readReport.CommitReport)
+	assert.Equal(t, commitReport, *readReport.CommitReport)
+}
+
 func TestGetMergedVersionReport(t *testing.T) {
 	tempFile, err := os.CreateTemp("", "test_merged_version_report.json")
 	require.NoError(t, err)
@@ -73,6 +107,102 @@ func TestGetMergedVersionReport(t *testing.T) {
 	assert.True(t, mergedReport.MustGenerate())
 }
 
+func TestGetMergedVersionReportWithCommitReports(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_merged_version_report_commit.json")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
+	defer os.Unsetenv(ENV_VAR_PREFIX)
+
+	commitReport1 := "Test commit report 1"
+	commitReport2 := "Test commit report 2"
+	reports := []VersionReport{
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &commitReport1},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: &commitReport2},
+	}
+
+	for _, report := range reports {
+		bytes, _ := json.Marshal(report)
+		tempFile.Write(append(bytes, '\n'))
+	}
+	tempFile.Close()
+
+	mergedReport, err := getMergedVersionReport()
+	require.NoError(t, err)
+
+	assert.Len(t, mergedReport.Reports, 2)
+	assert.Equal(t, "test1", mergedReport.Reports[0].Key)
+	assert.Equal(t, "test2", mergedReport.Reports[1].Key)
+	assert.Equal(t, "Test report 1\nTest report 2\n", mergedReport.GetMarkdownSection())
+	assert.Equal(t, "Test commit report 1\nTest commit report 2\n", mergedReport.GetCommitMarkdownSection())
+	assert.True(t, mergedReport.MustGenerate())
+}
+
+func TestGetMergedVersionReportWithMixedCommitReports(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_merged_version_report_mixed_commit.json")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
+	defer os.Unsetenv(ENV_VAR_PREFIX)
+
+	commitReport1 := "Test commit report 1"
+	// test2 has no commit report (nil)
+	reports := []VersionReport{
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &commitReport1},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: nil},
+	}
+
+	for _, report := range reports {
+		bytes, _ := json.Marshal(report)
+		tempFile.Write(append(bytes, '\n'))
+	}
+	tempFile.Close()
+
+	mergedReport, err := getMergedVersionReport()
+	require.NoError(t, err)
+
+	assert.Len(t, mergedReport.Reports, 2)
+	assert.Equal(t, "test1", mergedReport.Reports[0].Key)
+	assert.Equal(t, "test2", mergedReport.Reports[1].Key)
+	assert.Equal(t, "Test report 1\nTest report 2\n", mergedReport.GetMarkdownSection())
+	assert.Equal(t, "Test commit report 1\n", mergedReport.GetCommitMarkdownSection())
+	assert.True(t, mergedReport.MustGenerate())
+}
+
+func TestGetMergedVersionReportWithEmptyCommitReports(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_merged_version_report_empty_commit.json")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
+	defer os.Unsetenv(ENV_VAR_PREFIX)
+
+	emptyCommitReport1 := ""
+	emptyCommitReport2 := ""
+	reports := []VersionReport{
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: &emptyCommitReport1},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: &emptyCommitReport2},
+	}
+
+	for _, report := range reports {
+		bytes, _ := json.Marshal(report)
+		tempFile.Write(append(bytes, '\n'))
+	}
+	tempFile.Close()
+
+	mergedReport, err := getMergedVersionReport()
+	require.NoError(t, err)
+
+	assert.Len(t, mergedReport.Reports, 2)
+	assert.Equal(t, "test1", mergedReport.Reports[0].Key)
+	assert.Equal(t, "test2", mergedReport.Reports[1].Key)
+	assert.Equal(t, "Test report 1\nTest report 2\n", mergedReport.GetMarkdownSection())
+	assert.Equal(t, "", mergedReport.GetCommitMarkdownSection())
+	assert.True(t, mergedReport.MustGenerate())
+}
+
 func TestWithVersionReportCapture(t *testing.T) {
 	ctx := context.Background()
 
@@ -90,6 +220,30 @@ func TestWithVersionReportCapture(t *testing.T) {
 	assert.Len(t, report.Reports, 1)
 	assert.Equal(t, "test", report.Reports[0].Key)
 	assert.True(t, report.MustGenerate())
+}
+
+func TestWithVersionReportCaptureWithCommitReport(t *testing.T) {
+	ctx := context.Background()
+
+	type unknown struct{}
+	commitReport := "Test commit report"
+	report, _, err := WithVersionReportCapture[*unknown](ctx, func(ctx context.Context) (*unknown, error) {
+		return nil, AddVersionReport(ctx, VersionReport{
+			Key:          "test_commit",
+			Priority:     1,
+			MustGenerate: true,
+			PRReport:     "Test report",
+			CommitReport: &commitReport,
+		})
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, report.Reports, 1)
+	assert.Equal(t, "test_commit", report.Reports[0].Key)
+	assert.True(t, report.MustGenerate())
+	assert.NotNil(t, report.Reports[0].CommitReport)
+	assert.Equal(t, commitReport, *report.Reports[0].CommitReport)
+	assert.Equal(t, "Test commit report\n", report.GetCommitMarkdownSection())
 }
 
 func TestIntegrationWithSubprocesses(t *testing.T) {

--- a/versioning/report_test.go
+++ b/versioning/report_test.go
@@ -53,14 +53,13 @@ func TestAddVersionReportWithCommitReport(t *testing.T) {
 	defer os.Unsetenv(ENV_VAR_PREFIX)
 
 	ctx := context.Background()
-	commitReport := "Test commit report"
 	report := VersionReport{
 		Key:          "test_commit",
 		Priority:     1,
 		BumpType:     BumpMinor,
 		MustGenerate: true,
 		PRReport:     "Test report",
-		CommitReport: commitReport,
+		CommitReport: "Test commit report",
 	}
 
 	err = AddVersionReport(ctx, report)
@@ -74,7 +73,6 @@ func TestAddVersionReportWithCommitReport(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, report, readReport)
-	assert.Equal(t, commitReport, readReport.CommitReport)
 }
 
 func TestGetMergedVersionReport(t *testing.T) {
@@ -114,11 +112,9 @@ func TestGetMergedVersionReportWithCommitReports(t *testing.T) {
 	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
 	defer os.Unsetenv(ENV_VAR_PREFIX)
 
-	commitReport1 := "Test commit report 1"
-	commitReport2 := "Test commit report 2"
 	reports := []VersionReport{
-		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: commitReport1},
-		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: commitReport2},
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: "Test commit report 1"},
+		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: "Test commit report 2"},
 	}
 
 	for _, report := range reports {
@@ -146,10 +142,9 @@ func TestGetMergedVersionReportWithMixedCommitReports(t *testing.T) {
 	os.Setenv(ENV_VAR_PREFIX, tempFile.Name())
 	defer os.Unsetenv(ENV_VAR_PREFIX)
 
-	commitReport1 := "Test commit report 1"
 	// test2 has no commit report (empty string)
 	reports := []VersionReport{
-		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: commitReport1},
+		{Key: "test1", Priority: 2, MustGenerate: true, PRReport: "Test report 1", CommitReport: "Test commit report 1"},
 		{Key: "test2", Priority: 1, MustGenerate: false, PRReport: "Test report 2", CommitReport: ""},
 	}
 
@@ -223,14 +218,13 @@ func TestWithVersionReportCaptureWithCommitReport(t *testing.T) {
 	ctx := context.Background()
 
 	type unknown struct{}
-	commitReport := "Test commit report"
 	report, _, err := WithVersionReportCapture[*unknown](ctx, func(ctx context.Context) (*unknown, error) {
 		return nil, AddVersionReport(ctx, VersionReport{
 			Key:          "test_commit",
 			Priority:     1,
 			MustGenerate: true,
 			PRReport:     "Test report",
-			CommitReport: commitReport,
+			CommitReport: "Test commit report",
 		})
 	})
 
@@ -238,7 +232,7 @@ func TestWithVersionReportCaptureWithCommitReport(t *testing.T) {
 	assert.Len(t, report.Reports, 1)
 	assert.Equal(t, "test_commit", report.Reports[0].Key)
 	assert.True(t, report.MustGenerate())
-	assert.Equal(t, commitReport, report.Reports[0].CommitReport)
+	assert.Equal(t, "Test commit report", report.Reports[0].CommitReport)
 	assert.Equal(t, "Test commit report\n", report.GetCommitMarkdownSection())
 }
 


### PR DESCRIPTION
## Changes
Add commit messages to version reports

commit-messages field will be used transmit information from speakeasy cli to sdk-action.
These commit-messages will be used when creating commits in client repositories
